### PR TITLE
[Design] 프로젝트 추가 세팅

### DIFF
--- a/src/components/Navbar/Navbar.styles.ts
+++ b/src/components/Navbar/Navbar.styles.ts
@@ -5,6 +5,7 @@ import { NavLink } from 'react-router-dom';
 export const Navbar = styled.nav`
   position: fixed;
   inset: 0;
+  z-index: 10;
 
   display: flex;
   align-items: center;
@@ -19,7 +20,7 @@ export const Logo = styled.h1`
   width: 100%;
   padding: 0 48px;
 
-  color: #333;
+  color: ${palette.gray.grary333};
 
   font-size: 25.821px;
   font-weight: 600;
@@ -51,7 +52,7 @@ export const Menu = styled(NavLink)`
 
   &.active {
     background-color: ${palette.primary.primary500};
-    color: #fff;
+    color: ${palette.white};
 
     :hover {
       background-color: ${palette.primary.primary600};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -22,6 +22,7 @@ const palette = {
     primary200: '#A2EDD7',
     primary100: '#D0F7EA',
     primary050: '#F1FCF8',
+    primaryMain: '#27B999',
   },
   danger: {
     default: '#EC221F',
@@ -35,6 +36,11 @@ const palette = {
     default: '#E8B931',
     hover: '#E5A000',
   },
+  gray: {
+    grary333: '#333',
+    gray777: '#777',
+  },
+  white: '#fff',
 };
 
 export default palette;


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #6 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

포트폴리오 페이지 제작하면서 추가로 세팅할 부분이 생겨 추가했습니다.
- `컬러 팔레트` 색상 추가
- `Navbar` -> `z-index` 추가

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 네비게이션바 및 이미지
- 네비게이션바는 `z-index: 10`으로 설정되어 있습니다. 배경 이미지 겹치게 하기 위해 아래 참고해서 사용하면 됩니다.
- 배경 제외한 컨텐츠 부분에는 `z-index 6~9사이`로 줘서 `이미지 위, 네비게이션바 아래`있게 하면 됩니다.

```
position: fixed;
top: 0;
z-index: 5;
```

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

|`배경 예시`|
| -- |
| <img width="1709" height="141" alt="스크린샷 2025-11-10 오후 3 40 26" src="https://github.com/user-attachments/assets/5917fbce-fda9-40fe-a139-5f19ee7504e4" /> |

